### PR TITLE
docs: add starter + scaffold usage to unified setup

### DIFF
--- a/docs/README-unified-setup.md
+++ b/docs/README-unified-setup.md
@@ -20,3 +20,52 @@ redirect_from:
   - /src/chapter-old/
 ```
 
+
+## スターターテンプレートの利用
+
+新規書籍は `templates/starter/` の雛形をコピーして開始できます。
+
+- 収録物:
+  - `docs/_config.yml`（permalink: pretty、Pages対応plugins、kramdown、layout: book）
+  - `docs/_includes/page-navigation.html`（canonical）
+  - `docs/_includes/sidebar-nav.html`（テンプレ）
+  - `docs/_data/navigation.yml`（最小スケルトン）
+  - `docs/index.md`（トップ雛形。トップでは下部ナビを表示しません）
+
+手動手順（例）:
+
+```bash
+# 任意の作業ディレクトリで
+cp -R templates/starter/docs ./docs
+# _config.yml の <owner>/<repo> 等を自書籍に合わせて置換
+```
+
+## スキャフォールドスクリプトの利用
+
+`scripts/scaffold-new-book.sh` で雛形のコピーと基本置換を自動化できます。
+
+```bash
+# 乾燥実行（ローカルに雛形を展開）
+./scripts/scaffold-new-book.sh <owner> <repo>
+
+# GitHub上に新規リポを作成して初回pushまで実施
+./scripts/scaffold-new-book.sh <owner> <repo> --create
+```
+
+- 展開場所は一時ディレクトリに表示されます。`docs/_config.yml` の `title/description/author` を編集し、章/付録ディレクトリを追加してください。
+- 章/付録のURLはディレクトリ形式（末尾 /）で統一してください。
+
+## 章スラッグ変更時のリダイレクト
+
+`jekyll-redirect-from`（Pages標準）を推奨します。到達先ページのfront matterに旧URLを列挙してください。
+
+```yaml
+---
+layout: book
+title: 新しい章タイトル
+redirect_from:
+  - /src/chapter-old/
+---
+```
+
+スタブ方式にする場合は、旧URL側の `index.md/html` に front matter を付与して Liquid を評価させるか、絶対URLで `meta refresh` を指定してください（docs/examples/redirect-from-sample.md を参照）。


### PR DESCRIPTION
- Document templates/starter/ contents\n- Add usage for scripts/scaffold-new-book.sh\n- Clarify redirect-from recommendation and stub patterns