### PR TITLE
docs: add TROUBLESHOOTING; update prev/next nav guide

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,39 @@
+# Troubleshooting: Pages builds, workflows, and navigation
+
+This guide documents common pitfalls and fixes when rolling out book-formatter v3 across book repositories.
+
+## GitHub Actions: Workflow overwrite/merge issues
+- Symptom: A PR adding `.github/workflows/nav-link-check.yml` conflicts with an existing file, or overwrites customizations.
+- Cause: An older workflow exists or a downstream repo added local changes.
+- Fix/Guidance:
+  - Prefer creating a PR only when the content differs from the canonical template.
+  - In PRs, keep local customizations if they are intentional; otherwise replace with the canonical template.
+  - If you need per-repo tweaks, document them inline and add owners via `CODEOWNERS`.
+  - Scripts now avoid absolute paths and compare templates before proposing changes.
+
+## GitHub Pages build failures (YAML)
+- Symptom: Pages fails with YAML parse errors or navigation missing.
+- Known cases and fixes:
+  - `syntax_highlighter: rougepermalink: pretty` → Merge artifact; split into separate lines. Ensure `permalink: pretty` exists at top-level.
+  - Plugin bullets under `kramdown` or random sections → Move to a top-level `plugins:` block:
+    - `- jekyll-relative-links`
+    - `- jekyll-optional-front-matter`
+  - Conflicting or duplicate `permalink:` entries → Keep a single `permalink: pretty` at top-level.
+
+## Bottom navigation: no nav on top page
+- Symptom: “前へ/次へ” shows on the top page, or links point to `/` instead of `/<repo>/` on project Pages.
+- Fix:
+  - The canonical include detects the top page by stripping `site.baseurl` and suppresses bottom navigation on root.
+  - Avoid `permalink: /` on `docs/index.md` for project Pages. Let Jekyll emit top at `/<repo>/`.
+
+## Link checks and flakiness
+- Symptom: Scheduled Nav + Pages Link Check fails intermittently.
+- Guidance:
+  - Re-run the workflow. The job tolerates YAML parsing differences for `baseurl` and builds paths from `_data/navigation.yml` when present.
+  - For heavy repo sets, API rate limits may cause failures; stagger runs or reduce frequency.
+
+## Redirects and legacy slugs
+- Symptom: Old URLs 404 after restructuring chapters.
+- Fix:
+  - Add `redirect_from:` to moved pages, or create minimal stub pages under the old path to preserve inbound links.
+

--- a/docs/prev-next-navigation-guide.md
+++ b/docs/prev-next-navigation-guide.md
@@ -9,6 +9,14 @@
   3) URLグループごとのフォールバック（`/introduction/`, `/chapters/`, `/additional|/resources/`, `/appendices/`, `/afterword/`）
 - 最も確実なのは、`docs/_data/navigation.yml` を整備することです。章/付録の順序・タイトル・パスを明示的に定義してください。
 
+### タイトルの優先順位（Prev/Nextの表示）
+- `page.title` を最優先で使用します（ページ側が最新のため）。
+- 次点で `_data/navigation.yml` の `title`/`label`、最後に `name`/エントリ名を使用します。
+
+### トップページでは下部ナビを表示しない
+- プロジェクトPagesではトップは `/<repo>/`（`site.baseurl` 付き）です。
+- 共通インクルードは `site.baseurl` を取り除いてルートを判定し、トップページでは下部ナビを非表示にします。
+
 ## 2. よくある落とし穴（プロジェクトPages）
 - `docs/index.md` に `permalink: /` を設定しないでください。プロジェクトPages（`baseurl` あり）では、トップは `/<repo>/` に出力される必要があります。`permalink: /` があるとルート`/`に出力され、`/<repo>/` が 404 になります。
 - `baseurl` は `_config.yml` に設定します。引用符で囲んでも動作しますが、ワークフロー等で正しく扱うためにはYAMLとして解釈される前提で記述するのが望ましいです。
@@ -24,4 +32,3 @@
 ## 5. 参考
 - 共通インクルード: `docs/_includes/page-navigation.html`
 - 統一ガイド: `docs/book-format-unification-guide.md`
-


### PR DESCRIPTION
- Add TROUBLESHOOTING guide:
  - Workflow overwrite/merge guidance for nav-link-check
  - Common Pages YAML issues (rougepermalink, plugins, permalink)
  - Top page bottom-nav suppression and redirects guidance
- Update prev/next navigation guide:
  - Clarify title priority (page.title preferred)
  - Hide bottom navigation on the top page (project Pages)