### PR TITLE
chore: remove emojis from navigation templates

### DIFF
--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -83,7 +83,6 @@
     {% endif %}
     
     <a href="{{ site.baseurl }}/" class="nav-home">
-      <span class="icon">📚</span>
       <span class="label">目次へ</span>
     </a>
     
@@ -190,11 +189,6 @@
 
 .nav-next .arrow {
   margin-left: 0.5rem;
-}
-
-.nav-home .icon {
-  margin-right: 0.5rem;
-  font-size: 1.2rem;
 }
 
 .label {

--- a/docs/_includes/page-navigation.html
+++ b/docs/_includes/page-navigation.html
@@ -94,7 +94,6 @@ Order resolution strategy (first match wins):
     {% endif %}
 
     <a href="{{ '/' | relative_url }}" class="nav-home">
-      <span class="icon">📚</span>
       <span class="label">目次へ</span>
     </a>
 
@@ -126,4 +125,3 @@ Order resolution strategy (first match wins):
 .title { font-size: .9rem; opacity: .8; max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 @media (max-width: 768px) { .chapter-nav { flex-wrap: wrap; } .nav-prev, .nav-next { flex: 1 1 45%; } .nav-home { flex: 1 1 100%; order: -1; justify-content: center; } .title { display: none; } }
 </style>
-

--- a/docs/includes/page-navigation.html
+++ b/docs/includes/page-navigation.html
@@ -149,7 +149,6 @@ display ToC titles even when order falls back to site.pages.
     {% endif %}
 
     <a href="{{ '/' | relative_url }}" class="nav-home">
-      <span class="icon">📚</span>
       <span class="label">目次へ</span>
     </a>
 

--- a/templates/_includes/sidebar-nav.html
+++ b/templates/_includes/sidebar-nav.html
@@ -74,7 +74,7 @@
     <div class="external-links">
       {% if site.repository %}
       <a href="{% if site.repository contains 'http' %}{{ site.repository }}{% else %}https://github.com/{{ site.repository }}{% endif %}"
-         target="_blank" rel="noopener" class="external-link">💾 GitHub</a>
+         target="_blank" rel="noopener" class="external-link">GitHub</a>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
## 変更内容
- `docs/_includes/navigation.html`: 「目次へ」ボタンの📚アイコンを削除
- `docs/_includes/page-navigation.html` / `docs/includes/page-navigation.html`: 「目次へ」ボタンの📚アイコンを削除
- `templates/_includes/sidebar-nav.html`: フッターの「💾 GitHub」表記を「GitHub」に変更

## 意図
- 絵文字フォント混入による見た目のブレを避け、書籍間の体裁を揃えるため。

## 確認
- `npm test`（pass）
